### PR TITLE
Fix: File type of serviceAccount.json and checkout existing branch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Clone Repo, and `cd into the '/functions' directory`
 2. Run `npm install`
 3. On the Firebase Console **->Go to Communiti Project -> Project Settings -> Service ccounts -> Generate New Private Key**
-4. Rename the downloaded json file to _"serviceAccount.js"_ and add it to the `./functions/src/config` directory. **This file is the private key, and must be kept confidential. It is already added to the .gitignore file.**
+4. Rename the downloaded json file to _"serviceAccount.json"_ and add it to the `./functions/src/config` directory. **This file is the private key, and must be kept confidential. It is already added to the .gitignore file.**
 5. Install VS Code [Prettier Extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 6. Run `npm run start` on the _/functions_ folder.
 7. To open up the local Firebase Emulator UI visit [ http://127.0.0.1:4000/](http://127.0.0.1:4000/)
@@ -39,7 +39,7 @@ The Collaborative Workflows we'll be following can be summarized in these two gu
 4. Make updates and new additions in the previously created branch
 5. When the feature or bug-fix is complete, run `git checkout develop`
 6. Run `git pull` again fetch any updates from the dev branch
-7. Checkout your local working branch `git checkout -b dev-christian-oauth`
+7. Checkout your local working branch `git checkout dev-christian-oauth`
 8. Run `git merge develop` to locally merge your branch with the updated dev branch
 9. If there are no conflicts, simply run `git push --set-upstream origin dev-christian-oauth` and go to [github](https://github.com/makeitMVPadmin/Communiti-Platform/pulls), create a new Pull request. Important note: **Set base branch to Dev**.
 


### PR DESCRIPTION
Two changes made to README.md:
1. Updated serviceAccount.js to serviceAccount.json as discussed Monday night at All Hands meeting
2. Updated step 7 of Git Workflow (non-linked) section of README which was conflicting with step 3 attempting to checkout the branch already having been creating using "-b" again